### PR TITLE
Make functional on ZF 2.x

### DIFF
--- a/config/module.config.php
+++ b/config/module.config.php
@@ -15,9 +15,4 @@ return [
             'mobileDetect' => 'Neilime\MobileDetect\View\Helper\MobileDetectHelperFactory',
         ],
     ],
-    'controllers'        => [
-        'abstract_factories' => [
-            \Zend\Mvc\Controller\LazyControllerAbstractFactory::class,
-        ],
-    ],
 ];

--- a/src/MobileDetect/Factory/MobileDetectFactory.php
+++ b/src/MobileDetect/Factory/MobileDetectFactory.php
@@ -2,7 +2,8 @@
 namespace Neilime\MobileDetect\Factory;
 
 use Interop\Container\ContainerInterface;
-use Zend\ServiceManager\FActory\FactoryInterface;
+use Zend\ServiceManager\Factory\FactoryInterface;
+use Zend\ServiceManager\ServiceLocatorInterface;
 
 /**
  * Class MobileDetectFactory
@@ -19,5 +20,10 @@ class MobileDetectFactory implements FactoryInterface
     public function __invoke(ContainerInterface $serviceLocator, $requestedName, array $options = null)
     {
         return new \Mobile_Detect();
+    }
+
+    public function createService(ServiceLocatorInterface $serviceLocator)
+    {
+        return $this->__invoke($serviceLocator);
     }
 }

--- a/src/MobileDetect/Factory/MobileDetectFactory.php
+++ b/src/MobileDetect/Factory/MobileDetectFactory.php
@@ -2,7 +2,7 @@
 namespace Neilime\MobileDetect\Factory;
 
 use Interop\Container\ContainerInterface;
-use Zend\ServiceManager\Factory\FactoryInterface;
+use Zend\ServiceManager\FactoryInterface;
 use Zend\ServiceManager\ServiceLocatorInterface;
 
 /**

--- a/src/MobileDetect/Mvc/Controller/Plugin/MobileDetectPluginFactory.php
+++ b/src/MobileDetect/Mvc/Controller/Plugin/MobileDetectPluginFactory.php
@@ -2,7 +2,7 @@
 namespace Neilime\MobileDetect\Mvc\Controller\Plugin;
 
 use Interop\Container\ContainerInterface;
-use Zend\ServiceManager\Factory\FactoryInterface;
+use Zend\ServiceManager\FactoryInterface;
 use Zend\ServiceManager\ServiceLocatorInterface;
 
 class MobileDetectPluginFactory implements FactoryInterface
@@ -12,7 +12,7 @@ class MobileDetectPluginFactory implements FactoryInterface
         return new MobileDetectPlugin($serviceManager->get('mobileDetect'));
     }
 
-    public function createService(ServiceLocatorInterface $serviceLocator)
+    public function createService(gtiServiceLocatorInterface $serviceLocator)
     {
         return $this->__invoke($serviceLocator);
     }

--- a/src/MobileDetect/Mvc/Controller/Plugin/MobileDetectPluginFactory.php
+++ b/src/MobileDetect/Mvc/Controller/Plugin/MobileDetectPluginFactory.php
@@ -3,12 +3,17 @@ namespace Neilime\MobileDetect\Mvc\Controller\Plugin;
 
 use Interop\Container\ContainerInterface;
 use Zend\ServiceManager\Factory\FactoryInterface;
+use Zend\ServiceManager\ServiceLocatorInterface;
 
 class MobileDetectPluginFactory implements FactoryInterface
 {
     public function __invoke(ContainerInterface $serviceManager, $requestedName, array $options = null)
     {
-
         return new MobileDetectPlugin($serviceManager->get('mobileDetect'));
+    }
+
+    public function createService(ServiceLocatorInterface $serviceLocator)
+    {
+        return $this->__invoke($serviceLocator);
     }
 }

--- a/src/MobileDetect/View/Helper/MobileDetectHelperFactory.php
+++ b/src/MobileDetect/View/Helper/MobileDetectHelperFactory.php
@@ -3,11 +3,17 @@ namespace Neilime\MobileDetect\View\Helper;
 
 use Interop\Container\ContainerInterface;
 use Zend\ServiceManager\Factory\FactoryInterface;
+use Zend\ServiceManager\ServiceLocatorInterface;
 
 class MobileDetectHelperFactory implements FactoryInterface
 {
     public function __invoke(ContainerInterface $serviceLocator, $requestedName, array $options = null)
     {
         return new MobileDetectHelper($serviceLocator->get('mobileDetect'));
+    }
+
+    public function createService(ServiceLocatorInterface $serviceLocator)
+    {
+        return $this->__invoke($serviceLocator);
     }
 }

--- a/src/MobileDetect/View/Helper/MobileDetectHelperFactory.php
+++ b/src/MobileDetect/View/Helper/MobileDetectHelperFactory.php
@@ -2,7 +2,7 @@
 namespace Neilime\MobileDetect\View\Helper;
 
 use Interop\Container\ContainerInterface;
-use Zend\ServiceManager\Factory\FactoryInterface;
+use Zend\ServiceManager\FactoryInterface;
 use Zend\ServiceManager\ServiceLocatorInterface;
 
 class MobileDetectHelperFactory implements FactoryInterface

--- a/tests/configuration.php
+++ b/tests/configuration.php
@@ -1,2 +1,8 @@
 <?php
-return array();
+return [
+  'controllers'        => [
+      'abstract_factories' => [
+          \Zend\Mvc\Controller\LazyControllerAbstractFactory::class,
+      ],
+  ],
+];


### PR DESCRIPTION
This library does not actually work on older ZF versions; although it does claim so. I updated some parts that make it functional:

* Use factories that are two way compatible
* Some test code (an abstract controller) leaked out of this library; fixed that.